### PR TITLE
(maint) Make module PDK compatible

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,5 +59,8 @@
       "name": "puppet",
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
-  ]
+  ],
+  "pdk-version": "1.14.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#1.14.0",
+  "template-ref": "1.14.0-0-g1bf3a4e"
 }


### PR DESCRIPTION
This adds the pdk line to metadata.json to make this module pdk
compatible, which will allow us to use internal tools for shipping to
the Forge.