### PR TITLE
(maint) Make `auth` key optional when configuring plugin

### DIFF
--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -35,7 +35,7 @@ class Vault < TaskHelper
   }.freeze
 
   def validate_options(opts)
-    %i[server_url auth path].each do |key|
+    %i[server_url path].each do |key|
       unless opts[key]
         raise ValidationError, "Vault plugin requires #{key} to be configured"
       end


### PR DESCRIPTION
When this plugin was baked in to Bolt, the `auth` key was optional
because we also accepted the value as an environment variable. So we
didn't check if `auth` was set, then read the environment variable, and
did nothing if neither was set. When I moved this out to be a standalone
plugin I changed this to merge the user-set options over the ENV var
defaults, and then check that required keys were required, namely
`server-url` and `auth` which were not previously checked. However if
you're using an agent to connect to vault, you can connect Bolt directly
to the agent which authenticates with the vault server using it's own
certs, which doesn't require Bolt to authenticate with Vault. This means
the `auth` option is, in fact, optional. This PR removes it from
required key validation.