### PR TITLE
(maint) Make `auth` key optional when configuring plugin

### DIFF
--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -43,7 +43,7 @@ class Vault < TaskHelper
       cacert: ENV['VAULT_CACERT']
     }
 
-    env_opts.merge(auth: { method: 'token', token: ENV['VAULT_TOKEN'] }) if ENV['VAULT_TOKEN']
+    env_opts = env_opts.merge(auth: { method: 'token', token: ENV['VAULT_TOKEN'] }) if ENV['VAULT_TOKEN']
     merged = env_opts.merge(opts)
 
     validate_options(merged)

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -28,12 +28,6 @@ class Vault < TaskHelper
     "Accept" => "application/json"
   }.freeze
 
-  ENV_OPTS = {
-    server_url: ENV['VAULT_ADDR'],
-    auth: ENV['VAULT_TOKEN'],
-    cacert: ENV['VAULT_CACERT']
-  }.freeze
-
   def validate_options(opts)
     %i[server_url path].each do |key|
       unless opts[key]
@@ -44,11 +38,17 @@ class Vault < TaskHelper
 
   def task(opts)
     # Precedence: Inventory overrides config overrides env
-    merged = ENV_OPTS.merge(opts)
+    env_opts = {
+      server_url: ENV['VAULT_ADDR'],
+      cacert: ENV['VAULT_CACERT']
+    }
+
+    env_opts.merge(auth: { method: 'token', token: ENV['VAULT_TOKEN'] }) if ENV['VAULT_TOKEN']
+    merged = env_opts.merge(opts)
 
     validate_options(merged)
     header = {
-      "X-Vault-Token" => request_token(merged[:auth], merged)
+      "X-Vault-Token" => merged.fetch(:auth, nil) ? request_token(merged[:auth], merged) : nil
     }
 
     # Handle the different versions of the API


### PR DESCRIPTION
When this plugin was baked in to Bolt, the `auth` key was optional
because we also accepted the value as an environment variable. So we
didn't check if `auth` was set, then read the environment variable, and
did nothing if neither was set. When I moved this out to be a standalone
plugin I changed this to merge the user-set options over the ENV var
defaults, and then check that required keys were required, namely
`server-url` and `auth` which were not previously checked. However if
you're using an agent to connect to vault, you can connect Bolt directly
to the agent which authenticates with the vault server using it's own
certs, which doesn't require Bolt to authenticate with Vault. This means
the `auth` option is, in fact, optional. This PR removes it from
required key validation.