### PR TITLE
(maint) Updates for 0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Release 0.2.2
+
+### Bug fixes
+
+* **Make auth parameter optional** ([#8](https://github.com/puppetlabs/puppetlabs-vault/pulls/8))
+
+Previously the `auth` parameter was a required key to use the Vault plugin. It's now optional,
+enabling workflows such as connecting to a Vault agent which has it's own authentication with the
+server.
+
 ## Release 0.1.0
 
 This is the initial release.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-vault",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Puppet, Inc.",
   "summary": "A task to access Bolt configuration from secrets stored in a Hashicorp Vault server",
   "license": "Apache-2.0",


### PR DESCRIPTION
This updates the module to prep for the 0.2.2 release, updating the
CHANDLOG and metadata.json files