### PR TITLE
(maint) Set resolve_reference task to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
+## Release 0.3.0
+
+### New features
+
+* **Set `resolve_reference` task to private** ([#10](https://github.com/puppetlabs/puppetlabs-vault/pulls/10))
+
+    The `resolve_reference` task has been set to `private` so it no longer appears in UI lists.
+
 ## Release 0.2.2
 
 ### Bug fixes
 
 * **Make auth parameter optional** ([#8](https://github.com/puppetlabs/puppetlabs-vault/pulls/8))
 
-Previously the `auth` parameter was a required key to use the Vault plugin. It's now optional,
-enabling workflows such as connecting to a Vault agent which has it's own authentication with the
-server.
+    Previously the `auth` parameter was a required key to use the Vault plugin. It's now optional,
+    enabling workflows such as connecting to a Vault agent which has it's own authentication with the
+    server.
 
 ## Release 0.1.0
 

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -27,5 +27,6 @@
       "description": "Path to the CA certificate",
       "type": "Optional[String[1]]"
     }
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
This sets the `resolve_reference` task to private so it doesn't appear
in a task list when using `bolt task show`.

Part of puppetlabs/bolt#1599